### PR TITLE
Feature/method annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ dmypy.json
 
 # vscode settings
 .vscode/
+
+# test code
+test.py

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# vscode settings
+.vscode/

--- a/manga109api/manga109api.py
+++ b/manga109api/manga109api.py
@@ -16,19 +16,29 @@ class Parser(object):
         """
         self.root_dir = pathlib.Path(root_dir)
         self.books = []  # book titles
-        self.annotations = {}  # annotation in the form of dict
+        # self.annotations = {}  # annotation in the form of dict
 
-        with (self.root_dir / "books.txt").open("rt", encoding= 'utf-8') as f:
+        with (self.root_dir / "books.txt").open("rt", encoding='utf-8') as f:
             self.books = [line.rstrip() for line in f]
 
-        for book in self.books:
-            if book_titles != "all" and book not in book_titles:
-                continue
-            with (self.root_dir / "annotations" / (book + ".xml")).open("rt", encoding= 'utf-8') as f:
-                annotation = xmltodict.parse(f.read())
-            annotation = json.loads(json.dumps(annotation))  # OrderedDict -> dict
-            _convert_str_to_int_recursively(annotation)  # str -> int, for some attributes
-            self.annotations[book] = annotation
+        # for book in self.books:
+        #     if book_titles != "all" and book not in book_titles:
+        #         continue
+        #     with (self.root_dir / "annotations" / (book + ".xml")).open("rt", encoding= 'utf-8') as f:
+        #         annotation = xmltodict.parse(f.read())
+        #     annotation = json.loads(json.dumps(annotation))  # OrderedDict -> dict
+        #     _convert_str_to_int_recursively(annotation)  # str -> int, for some attributes
+        #     self.annotations[book] = annotation
+
+    def get_annotation(self, book):
+        """
+
+        """
+        with (self.root_dir / "annotations" / (book + ".xml")).open("rt", encoding='utf-8') as f:
+            annotation = xmltodict.parse(f.read())
+        annotation = json.loads(json.dumps(annotation))
+        _convert_str_to_int_recursively(annotation)
+        return annotation
 
     def img_path(self, book, index):
         """


### PR DESCRIPTION
初期読み込みが長いため，1冊分のxmlを読み込む関数を別に分けた．
Parserクラスのannotation変数を消し，get_annotation(book)によって逐一アノテーション情報を読み込む必要がある．
Parserクラスのbook_titlesは残してるけど現在はどこにも使っていない．